### PR TITLE
Add Goals model to schema, connected to User

### DIFF
--- a/prisma/migrations/20220711191031_feature_user_goals/migration.sql
+++ b/prisma/migrations/20220711191031_feature_user_goals/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Goals" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "waterIntakeGoal" INTEGER,
+    "proteinIntakeGoal" INTEGER,
+    "exerciseGoal" INTEGER,
+    "kegelsGoal" INTEGER,
+    "gardlandPoseGoal" INTEGER,
+
+    CONSTRAINT "Goals_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Goals" ADD CONSTRAINT "Goals_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   email             String      @unique
   expectedDueDate   String?  
   journalEntries    JournalEntry[]
+  goals             Goals[]
 }
 
 model JournalEntry {
@@ -37,4 +38,17 @@ model JournalEntry {
   authorId          String
   author            User        @relation(fields: [authorId], references: [id], onDelete: Cascade)
   waterIntake       Int
+}
+
+model Goals {
+  id                Int         @id @default(autoincrement())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  userId            String
+  user              User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  waterIntakeGoal   Int?
+  proteinIntakeGoal Int?
+  exerciseGoal      Int?
+  kegelsGoal        Int?
+  gardlandPoseGoal  Int?
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   ResolversEnhanceMap,
   JournalEntryCrudResolver,
   UserCrudResolver,
+  GoalsCrudResolver,
   relationResolvers
 } from "./generated/type-graphql";
 import express from "express";
@@ -43,6 +44,7 @@ async function main() {
     resolvers: [
       JournalEntryCrudResolver,
       UserCrudResolver,
+      GoalsCrudResolver,
       JournalEntryOverrideResolver,
       UserOverrideResolver,
       ...relationResolvers


### PR DESCRIPTION
What this PR does:
- Adds Goals Model to schema
- Goals are connected to a User
- Goals contain: waterIntakeGoal, proteinIntakeGoal, exerciseGoal, kegelsGoal, garlandPoseGoal