### PR TITLE
Create an empty goals row for a user when they create an account

### DIFF
--- a/src/views/graphql/userResolvers.ts
+++ b/src/views/graphql/userResolvers.ts
@@ -55,7 +55,20 @@ export class UserOverrideResolver {
         return !existingUser 
             ? prisma.user.create({
                 data: {
-                    id, displayName, email
+                    id, 
+                    displayName, 
+                    email, 
+                    goals: { 
+                        create: [ 
+                            { 
+                                waterIntakeGoal: null, 
+                                proteinIntakeGoal: null, 
+                                exerciseGoal: null, 
+                                kegelsGoal: null, 
+                                gardlandPoseGoal: null 
+                            } 
+                        ]
+                    }
                 }
             })
             : existingUser


### PR DESCRIPTION
What this PR does:
- When a user creates an account, we create an initial goals instance for them that is empty
- The idea is so that when the user is created they have a goals instance already which we can just mutate/update when they enter their goals later on