### PR TITLE
Correct spelling for loginUser Mutation

### DIFF
--- a/src/views/graphql/userResolvers.ts
+++ b/src/views/graphql/userResolvers.ts
@@ -65,7 +65,7 @@ export class UserOverrideResolver {
                                 proteinIntakeGoal: null, 
                                 exerciseGoal: null, 
                                 kegelsGoal: null, 
-                                gardlandPoseGoal: null 
+                                garlandPoseGoal: null 
                             } 
                         ]
                     }


### PR DESCRIPTION
What this PR does:
- Corrects the spelling of garlandPoseGoal for loginMutation